### PR TITLE
Feat: Support json running orders

### DIFF
--- a/input/runningorders/empty2.json
+++ b/input/runningorders/empty2.json
@@ -1,0 +1,125 @@
+{
+  "runningOrder": {
+    "ID": "filename2",
+    "Slug": "Evening show2",
+    "MosExternalMetaData": [
+      {
+        "MosSchema": "http://MYMOSSCHEMA",
+        "MosPayload": {
+          "attribute": "example"
+        },
+        "MosScope": "PLAYLIST"
+      }
+    ],
+    "Stories": [
+      {
+        "Slug": "TITLE A;STORY_A",
+        "ID": "STORY_A",
+        "Items": []
+      },
+      {
+        "Slug": "TITLE A;STORY_B",
+        "ID": "STORY_B",
+        "Items": []
+      },
+      {
+        "Slug": "TITLE A;STORY_C",
+        "ID": "STORY_C",
+        "Items": []
+      },
+      {
+        "Slug": "TITLE A;STORY_D",
+        "ID": "STORY_D",
+        "Items": []
+      },
+      {
+        "Slug": "TITLE B;STORY_E",
+        "ID": "STORY_E",
+        "Items": []
+      },
+      {
+        "Slug": "TITLE D;STORY_F",
+        "ID": "STORY_F",
+        "Items": []
+      },
+      {
+        "Slug": "TITLE D;STORY_G",
+        "ID": "STORY_G",
+        "Items": []
+      },
+      {
+        "Slug": "TITLE D;STORY_H",
+        "ID": "STORY_H",
+        "Items": []
+      },
+      {
+        "Slug": "TITLE E;STORY_I",
+        "ID": "STORY_I",
+        "Items": []
+      },
+      {
+        "Slug": "TITLE B;STORY_J",
+        "ID": "STORY_J",
+        "Items": []
+      },
+      {
+        "Slug": "TITLE C;STORY_K",
+        "ID": "STORY_K",
+        "Items": []
+      }
+    ]
+  },
+  "fullStories": [
+    {
+      "ID": "STORY_A",
+      "Slug": "TITLE A;STORY_A",
+      "MosExternalMetaData": [
+        {
+          "MosScope": "PLAYLIST",
+          "MosSchema": "http://MYMOSSCHEMA",
+          "MosPayload": {
+            "attribute": "example"
+          }
+        }
+      ],
+      "RunningOrderId": "filename",
+      "Body": [
+        {
+          "Type": "p",
+          "Content": {
+            "@name": "p",
+            "@type": "element"
+          }
+        },
+        {
+          "Type": "storyItem",
+          "Content": {
+            "ID": "4",
+            "ObjectID": "asdf1234",
+            "MOSID": "SPECIAL.ID.MOS",
+            "Slug": "The slug",
+            "MosExternalMetaData": [
+              {
+                "MosScope": "PLAYLIST",
+                "MosSchema": "http://MYMOSSCHEMA2",
+                "MosPayload": {
+                  "attribute": "example"
+                }
+              }
+            ],
+            "mosAbstract": "This is the Absctract",
+            "ObjectSlug": "This is the Slug"
+          }
+        },
+        {
+          "Type": "p",
+          "Content": {
+            "text": "This is an example text",
+            "@name": "p",
+            "@type": "text"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/input/util.ts
+++ b/input/util.ts
@@ -1,0 +1,28 @@
+import { IMOSROFullStory, MosString128 } from "mos-connection";
+
+export type NormalizeMosAttributes<T> = {
+	[P in keyof T]:
+		T[P] extends MosString128 ?
+		string :
+		T[P] extends MosString128 | undefined ?
+		string | undefined :
+		T[P] extends string | number | null | undefined ?
+		T[P] :
+		NormalizeMosAttributes<T[P]>
+}
+
+
+export function fixStoryBody(stories: Array<NormalizeMosAttributes<IMOSROFullStory>>): Array<NormalizeMosAttributes<IMOSROFullStory>> {
+    stories.forEach(story => {
+        story.Body.forEach(item => {
+            if (item.Type === 'p' && item.Content) {
+                if (item.Content['@type'] === 'element') {
+                    delete item.Content
+                } else if (item.Content['@type'] === 'text') {
+                    item.Content = item.Content['text']
+                }
+            }
+        })
+    })
+    return stories
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -90,7 +90,7 @@ function loadFile(requirePath) {
 
 	if (
 		mosData.runningOrder 
-		&& mosData.runningOrder.EditorialDuraion 
+		&& mosData.runningOrder.EditorialDuration 
 		&& !(mosData.runningOrder.EditorialDuration instanceof MosDuration)
 	) {
 		let s = mosData.runningOrder.EditorialDuration._duration
@@ -104,7 +104,7 @@ function loadFile(requirePath) {
 
 		mosData.runningOrder.EditorialDuration = new MosDuration(hh + ':' + mm + ':' + ss)
 	}
-	
+
 	return mosData
 }
 const monitors: { [id: string]: MOSMonitor } = {}

--- a/src/index.ts
+++ b/src/index.ts
@@ -388,7 +388,7 @@ class MOSMonitor {
 					} else if (operation.type === OperationType.UPDATE) {
 						const updatedStory = operation.content
 						this.commands.push(() => {
-							console.log('sendROInsertStories', ro.ID)
+							console.log('sendROReplaceStories', ro.ID)
 							return this.mosDevice.sendROReplaceStories(
 								{
 									RunningOrderID: ro.ID,
@@ -610,7 +610,7 @@ function fakeOnUpdatedRunningOrder(ro: IMOSRunningOrder, _fullStories: IMOSROFul
 					// })
 				} else if (operation.type === OperationType.UPDATE) {
 					// const updatedStory = operation.content
-					console.log('sendROInsertStories', ro.ID)
+					console.log('sendROReplaceStories', ro.ID)
 					// this.commands.push(() => {
 					// 	return this.mosDevice.sendROReplaceStories({
 					// 		RunningOrderID: ro.ID,

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ import {
 	MosDevice,
 	IMOSListMachInfo,
 	MosTime,
+	MosDuration,
 } from 'mos-connection'
 import { diffLists, ListEntry, OperationType } from './mosDiff'
 import * as crypto from 'crypto'
@@ -78,7 +79,33 @@ function triggerReload() {
 }
 function loadFile(requirePath) {
 	delete require.cache[require.resolve(requirePath)]
-	return require(requirePath)
+	const mosData = require(requirePath)
+	if (
+		mosData.runningOrder 
+		&& mosData.runningOrder.EditorialStart 
+		&& !(mosData.runningOrder.EditorialStart instanceof MosTime)
+	) {
+		mosData.runningOrder.EditorialStart = new MosTime(mosData.runningOrder.EditorialStart._time)
+	}
+
+	if (
+		mosData.runningOrder 
+		&& mosData.runningOrder.EditorialDuraion 
+		&& !(mosData.runningOrder.EditorialDuration instanceof MosDuration)
+	) {
+		let s = mosData.runningOrder.EditorialDuration._duration
+		let hh = Math.floor(s / 3600)
+		s -= hh * 3600
+
+		let mm = Math.floor(s / 60)
+		s -= mm * 60
+
+		let ss = Math.floor(s)
+
+		mosData.runningOrder.EditorialDuration = new MosDuration(hh + ':' + mm + ':' + ss)
+	}
+	
+	return mosData
 }
 const monitors: { [id: string]: MOSMonitor } = {}
 const runningOrderIds: { [id: string]: number } = {}

--- a/src/index.ts
+++ b/src/index.ts
@@ -233,7 +233,7 @@ function fetchRunningOrders() {
 			) {
 				return
 			}
-			if (filePath.match(/\.ts$/)) {
+			if (filePath.match(/(\.ts|.json)$/)) {
 				const fileContents = loadFile(requirePath)
 				const ro: IMOSRunningOrder = fileContents.runningOrder
 				ro.ID = new MosString128(filePath.replace(/[\W]/g, '_'))


### PR DESCRIPTION
To allow easy manipulation of rundowns by testing tools, allow rundowns to be represented as JSON documents. 

Also adds @Julusian util library to support runtime conversion of existing rundown snapshots.